### PR TITLE
Remove intermediate files for full render as single process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ HERO_RAW_FILES := $(wildcard hero5/*.MP4)
 HERO_JOIN_CONFIG = hero_join_config.txt
 HERO_JOIN_FILE = hero.join.mp4
 HERO_WAVEFORM_FILE = hero.waveform.mp4
-HERO_RENDER = hero_render.mp4
 HERO_OUTPUT_BITRATE = 30000k
 HERO_SCALING_FACTOR = 0.75
 HERO_GENERATED_FILES = hero.join.wav hero.waveform.mp4.background.png
@@ -18,7 +17,6 @@ MAX_JOIN_CONFIG = max_join_config.txt
 MAX_JOIN_FISHEYE_FILE = max.join.fisheye.mp4
 MAX_JOIN_FILE = max.join.mp4
 MAX_WAVEFORM_FILE = max.waveform.mp4
-MAX_RENDER = max_render.mp4
 MAX_OUTPUT_BITRATE = 30000k
 MAX_SCALING_FACTOR = 1.0
 MAX_GENERATED_FILES = max.join.wav max.waveform.mp4.background.png
@@ -40,24 +38,17 @@ TRACK_MAP_CHASE_VIDEO_TOOL=create_chase_video
 TRACK_MAP_CHASE_ZOOM_FACTOR=16
 TRACK_MAP_CHASE_VIDEO=map_chase.mp4
 
-# combined map render video
-TRACK_MAP_RENDER=track_map_render.mp4
-TRACK_MAP_OUTPUT_BITRATE=10000k
-
 TRACK_MAP_GENERATED_FILES = track_gps.kpx track_gps.bin map_overview.mp4.background.png
 TRACK_MAP_CACHED_FILES = $(wildcard $(TRACK_MAP_CACHE_DIR)/*.png)
 
 LOG_FILES = log_hero.join.mp4.txt \
-			log_hero_render.mp4.txt \
 			log_map_overview.mp4.txt \
 			log_max.join.mp4.txt \
-			log_max_render.mp4.txt \
 			log_track_gps.gpx.txt \
 			log_hero.waveform.mp4.txt \
 			log_map_chase.mp4.txt \
 			log_max.join.fisheye.mp4.txt \
 			log_max.waveform.mp4.txt \
-			log_track_map_render.mp4.txt \
 			log_full_render.mp4.txt
 
 FFMEG_BIN = ffmpeg
@@ -109,9 +100,9 @@ full_render: $(FULL_RENDER)
 
 clean:
 	@echo "${BOLD}clean derivative files - leave join files${NONE}"
-	rm -f $(HERO_WAVEFORM_FILE) $(HERO_GENERATED_FILES)  $(HERO_RENDER)
+	rm -f $(HERO_WAVEFORM_FILE) $(HERO_GENERATED_FILES)
 	rm -f $(MAX_WAVEFORM_FILE) $(MAX_RENDER) $(MAX_GENERATED_FILES)
-	rm -f $(TRACK_MAP_CHASE_VIDEO) $(TRACK_MAP_OVERVIEW_VIDEO) $(TRACK_MAP_RENDER) $(TRACK_GPX) $(TRACK_MAP_GENERATED_FILES)
+	rm -f $(TRACK_MAP_CHASE_VIDEO) $(TRACK_MAP_OVERVIEW_VIDEO) $(TRACK_GPX) $(TRACK_MAP_GENERATED_FILES)
 	rm -rf __pycache__ config.pyc
 
 clobber: clean logclean

--- a/Makefile
+++ b/Makefile
@@ -115,10 +115,6 @@ merged_map: $(MERGED_MAP_RENDER)
 
 .PHONY: all clean clobber distclean
 
-snapshot_makefile:
-	@echo "${BOLD}Snapshot the makefile used for the build${NONE}"
-	cp Makefile Makefile.build
-
 clean:
 	@echo "${BOLD}clean derivative files - leave join files${NONE}"
 	rm -f $(HERO_WAVEFORM_FILE) $(HERO_GENERATED_FILES)  $(HERO_RENDER)
@@ -150,6 +146,8 @@ DEFAULT_CONFIG = "TIME_OPTIONS = '-t 00:05:00.000'\nADVANCE_MAX_SECONDS = 0.000\
 $(BUILD_CONFIG):
 	@echo "${BOLD}generate build config file${NONE}"
 	@echo $(DEFAULT_CONFIG) > $@
+	@echo "${BOLD}Snapshot the makefile used for the build${NONE}"
+	cp Makefile Makefile.build
 
 # filter_audio_test = " \
 # [0:a] volume=$(shell $(READ_VOLUME_HERO)) [left]; \
@@ -176,7 +174,7 @@ $(BUILD_CONFIG):
 #=======================================================================================================
 
 # generate ffmpeg join config for hero files - needed by ffmpeg concat method
-$(HERO_JOIN_CONFIG): $(HERO_RAW_FILES) $(BUILD_CONFIG) # snapshot_makefile
+$(HERO_JOIN_CONFIG): $(HERO_RAW_FILES) $(BUILD_CONFIG)
 	@echo "${BOLD}generate hero ffmpeg join config file${NONE}"
 	FILE_LIST=`python -c "print('\n'.join(['file \'%s\'' % s for s in '$(HERO_RAW_FILES)'.split()]))"`; \
 	echo "$$FILE_LIST" > $@
@@ -254,7 +252,7 @@ $(HERO_RENDER): $(HERO_JOIN_FILE) $(HERO_WAVEFORM_FILE) $(BUILD_CONFIG)
 #=======================================================================================================
 
 # generate ffmpeg join config for max files
-$(MAX_JOIN_CONFIG): $(MAX_RAW_FILES) $(BUILD_CONFIG) # snapshot_makefile
+$(MAX_JOIN_CONFIG): $(MAX_RAW_FILES) $(BUILD_CONFIG)
 	@echo "${BOLD}generate max ffmpeg join config file${NONE}"
 	FILE_LIST=`python -c "print('\n'.join(['file \'%s\'' % s for s in '$(MAX_RAW_FILES)'.split()]))"`; \
 	echo "$$FILE_LIST" > $@

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ HERO_RAW_FILES := $(wildcard hero5/*.MP4)
 HERO_JOIN_CONFIG = hero_join_config.txt
 HERO_JOIN_FILE = hero.join.mp4
 HERO_WAVEFORM_FILE = hero.waveform.mp4
-HERO_OUTPUT_BITRATE = 30000k
 HERO_SCALING_FACTOR = 0.75
 HERO_GENERATED_FILES = hero.join.wav hero.waveform.mp4.background.png
 
@@ -17,7 +16,6 @@ MAX_JOIN_CONFIG = max_join_config.txt
 MAX_JOIN_FISHEYE_FILE = max.join.fisheye.mp4
 MAX_JOIN_FILE = max.join.mp4
 MAX_WAVEFORM_FILE = max.waveform.mp4
-MAX_OUTPUT_BITRATE = 30000k
 MAX_SCALING_FACTOR = 1.0
 MAX_GENERATED_FILES = max.join.wav max.waveform.mp4.background.png
 

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,8 @@ LOG_FILES = log_hero.join.mp4.txt \
 			log_max.waveform.mp4.txt \
 			log_merged_map_render.mp4.txt \
 			log_merged_render.mp4.txt \
-			log_track_map_render.mp4.txt
+			log_track_map_render.mp4.txt \
+			log_full_render.mp4.txt
 
 FFMEG_BIN = ffmpeg
 
@@ -104,7 +105,7 @@ BOLD=\033[1m
 UNDERLINE=\033[4m
 
 
-all: $(BUILD_CONFIG) merged_map
+all: $(BUILD_CONFIG) full_render
 
 # Comment "Makefile" out during development to be insensitive to changes in this file
 config: $(BUILD_CONFIG) # Makefile
@@ -114,6 +115,8 @@ merged: $(MERGED_RENDER)
 
 # Full merged map
 merged_map: $(MERGED_MAP_RENDER)
+
+full_render: $(FULL_RENDER)
 
 .PHONY: all clean clobber distclean
 
@@ -188,7 +191,7 @@ $(HERO_JOIN_FILE): $(HERO_JOIN_CONFIG)
 
 # generate waveform file
 $(HERO_WAVEFORM_FILE): $(HERO_JOIN_FILE)
-	@echo "${BOLD}generate waveform progress video${NONE}"
+	@echo "${BOLD}generate hero waveform progress video${NONE}"
 
 	$(eval MAXIMUM_JOIN_WIDTH:=$(call video_width, $(HERO_JOIN_FILE)))
 	$(eval MAXIMUM_SCALED_WIDTH:=$(call op_multiply, $(HERO_SCALING_FACTOR), $(MAXIMUM_JOIN_WIDTH)))
@@ -284,7 +287,7 @@ $(MAX_JOIN_FILE): $(MAX_JOIN_FISHEYE_FILE)
 
 # generate waveform file
 $(MAX_WAVEFORM_FILE): $(MAX_JOIN_FILE)
-	@echo "${BOLD}generate waveform progress video${NONE}"
+	@echo "${BOLD}generate max waveform progress video${NONE}"
 
 	$(eval MAXIMUM_JOIN_WIDTH:=$(call video_width, $(MAX_JOIN_FILE)))
 	$(eval MAXIMUM_SCALED_WIDTH:=$(call op_multiply, $(MAX_SCALING_FACTOR), $(MAXIMUM_JOIN_WIDTH)))

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ $(BUILD_CONFIG):
 #=======================================================================================================
 
 # generate ffmpeg join config for hero files - needed by ffmpeg concat method
-$(HERO_JOIN_CONFIG): $(HERO_RAW_FILES) $(BUILD_CONFIG) snapshot_makefile
+$(HERO_JOIN_CONFIG): $(HERO_RAW_FILES) $(BUILD_CONFIG) # snapshot_makefile
 	@echo "${BOLD}generate hero ffmpeg join config file${NONE}"
 	FILE_LIST=`python -c "print('\n'.join(['file \'%s\'' % s for s in '$(HERO_RAW_FILES)'.split()]))"`; \
 	echo "$$FILE_LIST" > $@
@@ -252,7 +252,7 @@ $(HERO_RENDER): $(HERO_JOIN_FILE) $(HERO_WAVEFORM_FILE) $(BUILD_CONFIG)
 #=======================================================================================================
 
 # generate ffmpeg join config for max files
-$(MAX_JOIN_CONFIG): $(MAX_RAW_FILES) $(BUILD_CONFIG) snapshot_makefile
+$(MAX_JOIN_CONFIG): $(MAX_RAW_FILES) $(BUILD_CONFIG) # snapshot_makefile
 	@echo "${BOLD}generate max ffmpeg join config file${NONE}"
 	FILE_LIST=`python -c "print('\n'.join(['file \'%s\'' % s for s in '$(MAX_RAW_FILES)'.split()]))"`; \
 	echo "$$FILE_LIST" > $@

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ MERGED_RENDER = merged_render.mp4
 MERGED_MAP_OUTPUT_BITRATE = 40000k
 MERGED_MAP_RENDER = merged_map_render.mp4
 
+FULL_RENDER = full_render.mp4
+
 WAVEFORM_VIDEO_TOOL = create_waveform_video
 
 TRACK_GPX = track_gps.gpx
@@ -483,18 +485,8 @@ $(MERGED_MAP_RENDER):  $(TRACK_MAP_RENDER) $(HERO_RENDER) $(MAX_RENDER)
 
 # combine video into full map render
 # $(MERGED_MAP_RENDER):  $(TRACK_MAP_RENDER) $(HERO_RENDER) $(MAX_RENDER)
-full_render.mp4: $(TRACK_MAP_CHASE_VIDEO) $(TRACK_MAP_OVERVIEW_VIDEO) $(MAX_JOIN_FILE) $(MAX_WAVEFORM_FILE) $(HERO_JOIN_FILE) $(HERO_WAVEFORM_FILE)
+$(FULL_RENDER): $(TRACK_MAP_CHASE_VIDEO) $(TRACK_MAP_OVERVIEW_VIDEO) $(MAX_JOIN_FILE) $(MAX_WAVEFORM_FILE) $(HERO_JOIN_FILE) $(HERO_WAVEFORM_FILE)
 	@echo "${BOLD}combine video and map renders into single view${NONE}"
-
-	@# $(eval HERO_TOP_HEIGHT:=$(call video_height, $(HERO_JOIN_FILE)))
-	@# $(eval HERO_TOP_HEIGHT_SCALED:=$(call op_multiply, $(HERO_SCALING_FACTOR), $(HERO_TOP_HEIGHT)))
-	@# $(eval HERO_TOP_WIDTH:=$(call video_width, $(HERO_JOIN_FILE)))
-	@# $(eval HERO_TOP_WIDTH_SCALED:=$(call op_multiply, $(HERO_SCALING_FACTOR), $(HERO_TOP_WIDTH)))
-	@# $(eval HERO_BOTTOM_HEIGHT:=$(call video_height, $(HERO_WAVEFORM_FILE)))
-	@# $(eval HERO_OUTPUT_WIDTH:=$(HERO_TOP_WIDTH_SCALED))
-	@# $(eval HERO_OUTPUT_HEIGHT:=$(call op_add, $(HERO_TOP_HEIGHT_SCALED), $(HERO_BOTTOM_HEIGHT)))
-	@# $(eval HERO_TOP_GEOMETRY:="$(HERO_TOP_WIDTH_SCALED)"x"$(HERO_TOP_HEIGHT_SCALED)")
-	@# $(eval HERO_GEOMETRY="$(HERO_OUTPUT_WIDTH)"x"$(HERO_OUTPUT_HEIGHT)")
 
 	@ #----------------------------------------------------------
 	$(eval HERO_HEIGHT:=$(call video_height, $(HERO_JOIN_FILE)))
@@ -506,17 +498,7 @@ full_render.mp4: $(TRACK_MAP_CHASE_VIDEO) $(TRACK_MAP_OVERVIEW_VIDEO) $(MAX_JOIN
 	$(eval HERO_WAVEFORM_HEIGHT:=$(call video_height, $(HERO_WAVEFORM_FILE)))
 	$(eval HERO_WAVEFORM_WIDTH:=$(call video_width, $(HERO_WAVEFORM_FILE)))
 
-	@ #==========================================================
-
-	@# $(eval MAX_TOP_HEIGHT:=$(call video_height, $(MAX_JOIN_FILE)))
-	@# $(eval MAX_TOP_HEIGHT_SCALED:=$(call op_multiply, $(MAX_SCALING_FACTOR), $(MAX_TOP_HEIGHT)))
-	@# $(eval MAX_TOP_WIDTH:=$(call video_width, $(MAX_JOIN_FILE)))
-	@# $(eval MAX_TOP_WIDTH_SCALED:=$(call op_multiply, $(MAX_SCALING_FACTOR), $(MAX_TOP_WIDTH)))
-	@# $(eval MAX_BOTTOM_HEIGHT:=$(call video_height, $(MAX_WAVEFORM_FILE)))
-	@# $(eval MAX_OUTPUT_WIDTH:=$(MAX_TOP_WIDTH_SCALED))
-	@# $(eval MAX_OUTPUT_HEIGHT:=$(call op_add, $(MAX_TOP_HEIGHT_SCALED), $(MAX_BOTTOM_HEIGHT)))
-	@# $(eval MAX_TOP_GEOMETRY:="$(MAX_TOP_WIDTH_SCALED)"x"$(MAX_TOP_HEIGHT_SCALED)")
-	@# $(eval MAX_GEOMETRY="$(MAX_OUTPUT_WIDTH)"x"$(MAX_OUTPUT_HEIGHT)")
+	@echo 1: $(HERO_GEOMETRY)
 
 	@ #----------------------------------------------------------
 
@@ -529,11 +511,7 @@ full_render.mp4: $(TRACK_MAP_CHASE_VIDEO) $(TRACK_MAP_OVERVIEW_VIDEO) $(MAX_JOIN
 	$(eval MAX_WAVEFORM_HEIGHT:=$(call video_height, $(MAX_WAVEFORM_FILE)))
 	$(eval MAX_WAVEFORM_WIDTH:=$(call video_width, $(MAX_WAVEFORM_FILE)))
 
-	@ #==========================================================
-
-	@# $(eval HERO_WIDTH := $(call video_width, $(HERO_RENDER)))
-	@# $(eval MAX_WIDTH := $(call video_width, $(MAX_RENDER)))
-	@# $(eval LEFT_WIDTH := $(call op_max, $(HERO_WIDTH), $(MAX_WIDTH)))
+	@echo 2: $(MAX_GEOMETRY)
 
 	@ #----------------------------------------------------------
 
@@ -541,19 +519,18 @@ full_render.mp4: $(TRACK_MAP_CHASE_VIDEO) $(TRACK_MAP_OVERVIEW_VIDEO) $(MAX_JOIN
 	$(eval RENDER_WIDTH := $(HERO_WIDTH_SCALED))
 	$(eval RENDER_HEIGHT := $(call op_add_4, $(HERO_HEIGHT_SCALED), $(HERO_WAVEFORM_HEIGHT), $(MAX_HEIGHT_SCALED), $(MAX_WAVEFORM_HEIGHT)))
 
-	@ #==========================================================
+	@echo 3: $(RENDER_WIDTH)
+	@echo 4: $(RENDER_HEIGHT)
 
-	@echo 1: $(LEFT_WIDTH)
-	@echo 2: $(HERO_WIDTH)
-	@echo 3: $(MAX_WIDTH)
+	@ #----------------------------------------------------------
 
 	$(eval TIME_MAX_RENDER := $(call duration_seconds, $(MAX_RENDER)))
 	$(eval TIME_HERO_RENDER := $(call duration_seconds, $(HERO_RENDER)))
 	$(eval TIME_FULL := $(call op_max, $(TIME_MAX_RENDER), $(TIME_HERO_RENDER)))
 
-	@echo 8: $(TIME_MAX_RENDER)
-	@echo 9: $(TIME_HERO_RENDER)
-	@echo 10: $(TIME_FULL)
+	@echo 5: $(TIME_MAX_RENDER)
+	@echo 6: $(TIME_HERO_RENDER)
+	@echo 7: $(TIME_FULL)
 
 	$(FFMEG_BIN) \
 		-y \

--- a/Makefile
+++ b/Makefile
@@ -486,7 +486,7 @@ $(MERGED_MAP_RENDER):  $(TRACK_MAP_RENDER) $(HERO_RENDER) $(MAX_RENDER)
 # combine video into full map render
 # $(MERGED_MAP_RENDER):  $(TRACK_MAP_RENDER) $(HERO_RENDER) $(MAX_RENDER)
 $(FULL_RENDER): $(TRACK_MAP_CHASE_VIDEO) $(TRACK_MAP_OVERVIEW_VIDEO) $(MAX_JOIN_FILE) $(MAX_WAVEFORM_FILE) $(HERO_JOIN_FILE) $(HERO_WAVEFORM_FILE)
-	@echo "${BOLD}combine video and map renders into single view${NONE}"
+	@echo "${BOLD}combine video, waveform and map renders into single view${NONE}"
 
 	@ #----------------------------------------------------------
 	$(eval HERO_HEIGHT:=$(call video_height, $(HERO_JOIN_FILE)))
@@ -524,14 +524,6 @@ $(FULL_RENDER): $(TRACK_MAP_CHASE_VIDEO) $(TRACK_MAP_OVERVIEW_VIDEO) $(MAX_JOIN_
 
 	@ #----------------------------------------------------------
 
-	$(eval TIME_MAX_RENDER := $(call duration_seconds, $(MAX_RENDER)))
-	$(eval TIME_HERO_RENDER := $(call duration_seconds, $(HERO_RENDER)))
-	$(eval TIME_FULL := $(call op_max, $(TIME_MAX_RENDER), $(TIME_HERO_RENDER)))
-
-	@echo 5: $(TIME_MAX_RENDER)
-	@echo 6: $(TIME_HERO_RENDER)
-	@echo 7: $(TIME_FULL)
-
 	$(FFMEG_BIN) \
 		-y \
 		-i $(HERO_JOIN_FILE) \
@@ -555,6 +547,6 @@ $(FULL_RENDER): $(TRACK_MAP_CHASE_VIDEO) $(TRACK_MAP_OVERVIEW_VIDEO) $(MAX_JOIN_
 			" \
 		-map "[out]" \
 		-b:v $(MERGED_MAP_OUTPUT_BITRATE) \
-		-t $(TIME_FULL) \
+		$(READ_TIME_OPTIONS) \
 		-r 23.98 \
 		$@ > log_$@.txt 2>&1


### PR DESCRIPTION
Removal of intermediate files should simplify handling and possibly make the process faster.